### PR TITLE
fix(ios): resolve root VC for SceneDelegate apps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ migrate_working_dir/
 build/
 
 .vscode
+
+CLAUDE.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.1 (19th Jun 2026)
+### iOS
+- [fix] SceneDelegate support in `initialize` root VC lookup
+
 ## 1.1.0 (12th Feb 2026)
 ### Android
 - [fix] security exception and mutex fix

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
+		C27123312FE59D5000060ECB /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C27123302FE59D4800060ECB /* SceneDelegate.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -48,6 +49,7 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		C27123302FE59D4800060ECB /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -114,6 +116,7 @@
 			isa = PBXGroup;
 			children = (
 				542A88A72C75D2A7001F21B0 /* Runner.entitlements */,
+				C27123302FE59D4800060ECB /* SceneDelegate.swift */,
 				97C146FA1CF9000F007C117D /* Main.storyboard */,
 				97C146FD1CF9000F007C117D /* Assets.xcassets */,
 				97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */,
@@ -157,7 +160,7 @@
 		97C146E61CF9000F007C117D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1430;
+				LastUpgradeCheck = 1510;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					97C146ED1CF9000F007C117D = {
@@ -278,6 +281,7 @@
 			files = (
 				74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */,
 				1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */,
+				C27123312FE59D5000060ECB /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -345,7 +349,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;
@@ -427,7 +431,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -477,7 +481,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;

--- a/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1430"
+   LastUpgradeVersion = "1510"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,6 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      customLLDBInitFile = "$(SRCROOT)/Flutter/ephemeral/flutter_lldbinit"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <MacroExpansion>
          <BuildableReference
@@ -43,11 +44,13 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      customLLDBInitFile = "$(SRCROOT)/Flutter/ephemeral/flutter_lldbinit"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
+      enableGPUValidationMode = "1"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/example/ios/Runner/AppDelegate.swift
+++ b/example/ios/Runner/AppDelegate.swift
@@ -8,17 +8,19 @@ import OtplessBM
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
+    print("[OtplessExample] AppDelegate.application(didFinishLaunchingWithOptions:) — AppDelegate is wired in")
     GeneratedPluginRegistrant.register(with: self)
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }
-    
+
     override func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
+        print("[OtplessExample] AppDelegate.application(open:) url=\(url)")
         super.application(app, open: url, options: options)
         if Otpless.shared.isOtplessDeeplink(url: url){
             Task {
                 await Otpless.shared.handleDeeplink(url)
             }
-           
+
         }
         return true
     }

--- a/example/ios/Runner/Info.plist
+++ b/example/ios/Runner/Info.plist
@@ -35,6 +35,27 @@
 			</array>
 		</dict>
 	</array>
+    <!-- BEGIN: SceneDelegate manifest — comment out this entire block (BEGIN…END) to test AppDelegate-only mode -->
+    <key>UIApplicationSceneManifest</key>
+    <dict>
+        <key>UIApplicationSupportsMultipleScenes</key>
+        <false/>
+        <key>UISceneConfigurations</key>
+        <dict>
+            <key>UIWindowSceneSessionRoleApplication</key>
+            <array>
+                <dict>
+                    <key>UISceneConfigurationName</key>
+                    <string>Default Configuration</string>
+                    <key>UISceneDelegateClassName</key>
+                    <string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+                    <key>UISceneStoryboardFile</key>
+                    <string>Main</string>
+                </dict>
+            </array>
+        </dict>
+    </dict>
+    <!-- END: SceneDelegate manifest -->
 	<key>CFBundleVersion</key>
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>FlutterDeepLinkingEnabled</key>

--- a/example/ios/Runner/SceneDelegate.swift
+++ b/example/ios/Runner/SceneDelegate.swift
@@ -1,0 +1,30 @@
+//
+//  SceneDelegate.swift
+//  Runner
+//
+//  Created by digvijay singh on 19/06/26.
+//
+
+import UIKit
+import OtplessBM
+
+@available(iOS 13.0, *)
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+    var window: UIWindow?
+
+    func scene(_ scene: UIScene,
+               willConnectTo session: UISceneSession,
+               options connectionOptions: UIScene.ConnectionOptions) {
+        print("[OtplessExample] SceneDelegate.scene(willConnectTo:) — SceneDelegate is wired in")
+        guard let _ = (scene as? UIWindowScene) else { return }
+    }
+
+    func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
+        print("[OtplessExample] SceneDelegate.scene(openURLContexts:) urls=\(URLContexts.map { $0.url })")
+        guard let url = URLContexts.first?.url else { return }
+        guard Otpless.shared.isOtplessDeeplink(url: url) else { return }
+        Task { await Otpless.shared.handleDeeplink(url) }
+    }
+}
+
+

--- a/ios/Classes/SwiftOtplessFlutterHeadless.swift
+++ b/ios/Classes/SwiftOtplessFlutterHeadless.swift
@@ -34,9 +34,12 @@ public class SwiftOtplessFlutterHeadless: NSObject, FlutterPlugin {
             start(withDict: arguments)
             result(nil)
         case "initialize":
-            guard let viewController = UIApplication.shared.delegate?.window??.rootViewController else {return}
             let args = call.arguments as! [String: Any]
             let appId = args["appId"] as! String
+            guard let viewController = Self.rootViewController() else {
+                result(nil)
+                return
+            }
             Otpless.shared.initialise(withAppId: appId, vc: viewController)
             result(nil)
         case "setResponseCallback":
@@ -129,6 +132,23 @@ public class SwiftOtplessFlutterHeadless: NSObject, FlutterPlugin {
         return otplessRequest
     }
     
+    @MainActor
+    private static func rootViewController() -> UIViewController? {
+        // SceneDelegate apps (iOS 13+)
+        if let vc = UIApplication.shared.connectedScenes
+            .compactMap({ $0 as? UIWindowScene })
+            .flatMap({ $0.windows })
+            .first(where: { $0.isKeyWindow })?.rootViewController {
+            return vc
+        }
+
+        // AppDelegate-only apps (legacy / no SceneDelegate)
+        if let vc = (UIApplication.shared.delegate as? FlutterAppDelegate)?.window?.rootViewController {
+            return vc
+        }
+        return UIApplication.shared.delegate?.window??.rootViewController
+    }
+
     static func filterParamsCondition(_ call: FlutterMethodCall, on onHaving: ([String: Any]) -> Void, off onNotHaving: () -> Void) {
         if let args = call.arguments as? [String: Any] {
             if let jsonString = args["arg"] as? String {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: otpless_headless_flutter
 description: Standalone SDK for Otpless Headless functionality.
-version: 1.1.0
+version: 1.1.1
 homepage: https://github.com/otpless-tech/flutter-headless-sdk.git
 
 environment:


### PR DESCRIPTION
Or slightly more context:

fix(ios): support SceneDelegate in initialize root VC lookup

Walks UIApplication.connectedScenes for the key window's rootViewController, with FlutterAppDelegate.window fallback for legacy AppDelegate-only apps. Bumps to 1.1.1.